### PR TITLE
Add simple load tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codex-game.github.io",
+  "version": "1.0.0",
+  "description": "This repository contains a simple WebGPU based demo used for the Codex Game GitHub Pages site. The demo renders a small animated water scene.",
+  "main": "main.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { test } = require('node:test');
+const { execSync } = require('child_process');
+const { pathToFileURL } = require('url');
+
+test('index.html includes game elements', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  assert(html.includes('<canvas id="gfx"'));
+  assert(html.includes('<script type="module" src="./main.js"'));
+});
+
+test('main.js syntax is valid', () => {
+  execSync(`node --check ${path.join(__dirname, '..', 'main.js')}`);
+});
+
+test('main.js handles unsupported browsers', async () => {
+  const canvas = {};
+  const unsupported = { style: { display: 'none' } };
+  global.document = {
+    getElementById(id) {
+      if (id === 'gfx') return canvas;
+      if (id === 'unsupported') return unsupported;
+      return null;
+    }
+  };
+
+  global.window = {
+    addEventListener(event, handler) {
+      if (event === 'DOMContentLoaded') handler();
+    }
+  };
+
+  global.navigator = {};
+
+  const moduleUrl = pathToFileURL(path.join(__dirname, '..', 'main.js')).href;
+  await import(moduleUrl);
+
+  assert.strictEqual(unsupported.style.display, 'block');
+});


### PR DESCRIPTION
## Summary
- add Node-based tests verifying basic page structure and script
- add a script to run tests using Node's built-in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd173e214832a95416c4f335372ff